### PR TITLE
[#4]test: email과 password를 통한 member 조회 테스트 작성

### DIFF
--- a/src/main/java/soma/haeya/edupi_db/member/controller/MemberController.java
+++ b/src/main/java/soma/haeya/edupi_db/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package soma.haeya.edupi_db.member.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,7 +24,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public ResponseEntity<SuccessResponse> createPost(@RequestBody SignupRequest signupRequest) {
+    public ResponseEntity<SuccessResponse> createPost(@Valid @RequestBody SignupRequest signupRequest) {
         memberService.saveMember(signupRequest);
 
         SuccessResponse response = new SuccessResponse("회원가입 성공");
@@ -34,7 +35,7 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
         LoginResponse loginResponse = memberService.findMemberByEmailAndPassword(loginRequest);
 
         return ResponseEntity

--- a/src/main/java/soma/haeya/edupi_db/member/controller/MemberController.java
+++ b/src/main/java/soma/haeya/edupi_db/member/controller/MemberController.java
@@ -34,8 +34,8 @@ public class MemberController {
             .body(response);
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
+    @PostMapping("/findByEmailAndPassword")
+    public ResponseEntity<LoginResponse> findMemberByEmailAndPassword(@Valid @RequestBody LoginRequest loginRequest) {
         LoginResponse loginResponse = memberService.findMemberByEmailAndPassword(loginRequest);
 
         return ResponseEntity

--- a/src/main/java/soma/haeya/edupi_db/member/dto/request/LoginRequest.java
+++ b/src/main/java/soma/haeya/edupi_db/member/dto/request/LoginRequest.java
@@ -1,10 +1,23 @@
 package soma.haeya.edupi_db.member.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class LoginRequest {
 
+    @NotBlank(message = "이메일은 공백이 아니어야 합니다.")
+    @Email(message = "잘못된 이메일 형식입니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 공백이 아니어야 합니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8에서 20자 이내여야 합니다.")
+    @Pattern(regexp = "^(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).*$", message = "비밀번호는 최소 1개의 특수기호를 포함해야 합니다.")
     private String password;
+
 }

--- a/src/main/java/soma/haeya/edupi_db/member/repository/MemberRepository.java
+++ b/src/main/java/soma/haeya/edupi_db/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package soma.haeya.edupi_db.member.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import soma.haeya.edupi_db.member.domain.Member;
 
@@ -7,7 +8,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
-    Member findMemberByEmail(String email);
+    Optional<Member> findMemberByEmail(String email);
 }
 
 

--- a/src/main/java/soma/haeya/edupi_db/member/service/MemberService.java
+++ b/src/main/java/soma/haeya/edupi_db/member/service/MemberService.java
@@ -40,11 +40,14 @@ public class MemberService {
     }
 
     public LoginResponse findMemberByEmailAndPassword(LoginRequest loginRequest) {
-        Member findMember = memberRepository.findMemberByEmail(loginRequest.getEmail());
+        Member findMember = memberRepository.findMemberByEmail(loginRequest.getEmail()).orElseThrow(
+            // 이메일이 일치하지 않는 경우
+            () -> new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다.")
+        );
 
         // 비밀번호가 일치하지 않는 경우
         if (!passwordEncoder.matches(loginRequest.getPassword(), findMember.getPassword())) {
-            throw new UserFriendlyException("비밀번호가 일치하지 않습니다.");
+            throw new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다.");
         }
 
         return LoginResponse.of(findMember);

--- a/src/test/java/soma/haeya/edupi_db/member/controller/MemberControllerTest.java
+++ b/src/test/java/soma/haeya/edupi_db/member/controller/MemberControllerTest.java
@@ -1,0 +1,75 @@
+package soma.haeya.edupi_db.member.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import soma.haeya.edupi_db.member.dto.request.LoginRequest;
+import soma.haeya.edupi_db.member.dto.response.LoginResponse;
+import soma.haeya.edupi_db.member.service.MemberService;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @MockBean
+    MemberService memberService;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "asdf", "asdf@naver", "asdf.com"})
+    @DisplayName("잘못된 email 형식으로 로그인")
+    void loginWithWrongEmailFormat(String email) throws Exception {
+        LoginRequest loginRequest = new LoginRequest(email, "asdf1234");
+
+        mockMvc.perform(post("/member/login")
+            .content(mapper.writeValueAsString(loginRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "asdf", "asdf1234"})
+    @DisplayName("잘못된 password 형식으로 로그인")
+    void loginWithWrongPasswordFormat(String password) throws Exception {
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", password);
+
+        mockMvc.perform(post("/member/login")
+            .content(mapper.writeValueAsString(loginRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("올바른 email, password로 로그인")
+    void login() throws Exception {
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234!");
+        LoginResponse response = new LoginResponse("asdf@naver.com", "홍길동", "ROLE_USER");
+
+        when(memberService.findMemberByEmailAndPassword(loginRequest))
+            .thenReturn(response);
+
+        mockMvc.perform(post("/member/login")
+            .content(mapper.writeValueAsString(loginRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/soma/haeya/edupi_db/member/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_db/member/service/MemberServiceTest.java
@@ -40,8 +40,7 @@ class MemberServiceTest {
             new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다."));
 
         Assertions.assertThatThrownBy(() -> memberService.findMemberByEmailAndPassword(loginRequest))
-            .isInstanceOf(UserFriendlyException.class)
-            .hasMessage("이메일 혹은 비밀번호가 일치하지 않습니다.");
+            .isInstanceOf(UserFriendlyException.class).hasMessage("이메일 혹은 비밀번호가 일치하지 않습니다.");
 
     }
 
@@ -49,24 +48,15 @@ class MemberServiceTest {
     @DisplayName("db에 저장된 member와 다른 비밀번호를 사용해 로그인")
     void findMemberByEmailAndPasswordFailPassword() {
 
-        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234");
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "differentPassword");
 
-        when(memberRepository.findMemberByEmail(anyString())).thenReturn(
-            Optional.of(
-                Member.builder()
-                    .email("asdf@naver.com")
-                    .password("differentPassword")
-                    .role("ROLE_USER")
-                    .name("홍길동")
-                    .build())
-        );
+        when(memberRepository.findMemberByEmail(anyString())).thenReturn(Optional.of(
+            Member.builder().email("asdf@naver.com").password("asdf1234!").role("ROLE_USER").name("홍길동").build()));
         when(passwordEncoder.matches(anyString(), anyString())).thenThrow(
-            new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다.")
-        );
+            new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다."));
 
         Assertions.assertThatThrownBy(() -> memberService.findMemberByEmailAndPassword(loginRequest))
-            .isInstanceOf(UserFriendlyException.class)
-            .hasMessage("이메일 혹은 비밀번호가 일치하지 않습니다.");
+            .isInstanceOf(UserFriendlyException.class).hasMessage("이메일 혹은 비밀번호가 일치하지 않습니다.");
 
     }
 
@@ -74,18 +64,11 @@ class MemberServiceTest {
     @DisplayName("유효한 이메일과 비밀번호를 사용해 로그인")
     void findMemberByEmailAndPasswordSuccess() {
 
-        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234");
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234!");
         LoginResponse expected = new LoginResponse("asdf@naver.com", "홍길동", "ROLE_USER");
 
-        when(memberRepository.findMemberByEmail(anyString()))
-            .thenReturn(
-                Optional.of(Member.builder()
-                    .email("asdf@naver.com")
-                    .password("differentPassword")
-                    .role("ROLE_USER")
-                    .name("홍길동")
-                    .build()
-                ));
+        when(memberRepository.findMemberByEmail(anyString())).thenReturn(Optional.of(
+            Member.builder().email("asdf@naver.com").password("asdf1234!").role("ROLE_USER").name("홍길동").build()));
         when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
 
         LoginResponse result = memberService.findMemberByEmailAndPassword(loginRequest);

--- a/src/test/java/soma/haeya/edupi_db/member/service/MemberServiceTest.java
+++ b/src/test/java/soma/haeya/edupi_db/member/service/MemberServiceTest.java
@@ -1,0 +1,95 @@
+package soma.haeya.edupi_db.member.service;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import soma.haeya.edupi_db.member.domain.Member;
+import soma.haeya.edupi_db.member.dto.request.LoginRequest;
+import soma.haeya.edupi_db.member.dto.response.LoginResponse;
+import soma.haeya.edupi_db.member.exception.UserFriendlyException;
+import soma.haeya.edupi_db.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("db에 저장되지 않은 이메일을 사용해 로그인")
+    void findMemberByEmailAndPasswordFailEmail() {
+
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234");
+
+        when(memberRepository.findMemberByEmail(anyString())).thenThrow(
+            new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다."));
+
+        Assertions.assertThatThrownBy(() -> memberService.findMemberByEmailAndPassword(loginRequest))
+            .isInstanceOf(UserFriendlyException.class)
+            .hasMessage("이메일 혹은 비밀번호가 일치하지 않습니다.");
+
+    }
+
+    @Test
+    @DisplayName("db에 저장된 member와 다른 비밀번호를 사용해 로그인")
+    void findMemberByEmailAndPasswordFailPassword() {
+
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234");
+
+        when(memberRepository.findMemberByEmail(anyString())).thenReturn(
+            Optional.of(
+                Member.builder()
+                    .email("asdf@naver.com")
+                    .password("differentPassword")
+                    .role("ROLE_USER")
+                    .name("홍길동")
+                    .build())
+        );
+        when(passwordEncoder.matches(anyString(), anyString())).thenThrow(
+            new UserFriendlyException("이메일 혹은 비밀번호가 일치하지 않습니다.")
+        );
+
+        Assertions.assertThatThrownBy(() -> memberService.findMemberByEmailAndPassword(loginRequest))
+            .isInstanceOf(UserFriendlyException.class)
+            .hasMessage("이메일 혹은 비밀번호가 일치하지 않습니다.");
+
+    }
+
+    @Test
+    @DisplayName("유효한 이메일과 비밀번호를 사용해 로그인")
+    void findMemberByEmailAndPasswordSuccess() {
+
+        LoginRequest loginRequest = new LoginRequest("asdf@naver.com", "asdf1234");
+        LoginResponse expected = new LoginResponse("asdf@naver.com", "홍길동", "ROLE_USER");
+
+        when(memberRepository.findMemberByEmail(anyString()))
+            .thenReturn(
+                Optional.of(Member.builder()
+                    .email("asdf@naver.com")
+                    .password("differentPassword")
+                    .role("ROLE_USER")
+                    .name("홍길동")
+                    .build()
+                ));
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+
+        LoginResponse result = memberService.findMemberByEmailAndPassword(loginRequest);
+
+        Assertions.assertThat(result).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #4 

## 📝 작업 내용

- email과 password 요청에 대한 valid 추가
- controller와 service 테스트코드 작성
- URI, controller 네이밍 변경

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- signup() 에 @Valid가 빠져있어 추가헀습니다
- 로그인 과정에서 쓰는 함수이지만 실제로 login 로직을 포함하고 있지 않아 controller 이름을 바꿨습니다.
