### PR TITLE
[#40]feat: ClassroomAccount ActionStatus(진행중, 도움, 완료) 추가

### DIFF
--- a/src/main/java/soma/edupimeta/classroom/ClassroomController.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomController.java
@@ -42,11 +42,10 @@ public class ClassroomController implements ClassroomOpenApi {
             .body(myClassroomsResponse);
     }
 
-    @Override
     @PostMapping("/v1/classroom/action/initialization")
-    public ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest) {
+    public ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitializeRequest actionInitializeRequest) {
         log.info("Initial classroom id: {}", actionInitializeRequest.getClassroomId());
-        long updateCount = classroomService.initializeClassroomAccountActionStatus(
+        long updateCount = classroomService.initAllActionStatusBy(
             actionInitializeRequest.getClassroomId()
         );
 

--- a/src/main/java/soma/edupimeta/classroom/ClassroomController.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomController.java
@@ -1,5 +1,6 @@
 package soma.edupimeta.classroom;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
-import soma.edupimeta.classroom.models.MyClassroomsResponse;
+import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.ClassroomService;
 import soma.edupimeta.classroom.service.domain.Classroom;
 
@@ -30,8 +31,8 @@ public class ClassroomController implements ClassroomOpenApi {
 
     @Override
     @GetMapping("/v1/classroom")
-    public ResponseEntity<MyClassroomsResponse> getMyClassrooms(Long accountId) {
-        MyClassroomsResponse myClassroomsResponse = classroomService.getMyClassrooms(accountId);
+    public ResponseEntity<List<MyClassroomResponse>> getMyClassrooms(Long accountId) {
+        List<MyClassroomResponse> myClassroomsResponse = classroomService.getMyClassrooms(accountId);
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/soma/edupimeta/classroom/ClassroomController.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomController.java
@@ -2,17 +2,20 @@ package soma.edupimeta.classroom;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.ClassroomService;
 import soma.edupimeta.classroom.service.domain.Classroom;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ClassroomController implements ClassroomOpenApi {
@@ -37,6 +40,19 @@ public class ClassroomController implements ClassroomOpenApi {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(myClassroomsResponse);
+    }
+
+    @Override
+    @PostMapping("/v1/classroom/action/initialization")
+    public ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest) {
+        log.info("Initial classroom id: {}", actionInitializeRequest.getClassroomId());
+        long updateCount = classroomService.initializeClassroomAccountActionStatus(
+            actionInitializeRequest.getClassroomId()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(updateCount);
     }
 }
 

--- a/src/main/java/soma/edupimeta/classroom/ClassroomController.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomController.java
@@ -8,8 +8,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import soma.edupimeta.classroom.account.models.ActionInitRequest;
+import soma.edupimeta.classroom.models.ClassroomInfoResponse;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.ClassroomService;
@@ -53,5 +55,16 @@ public class ClassroomController implements ClassroomOpenApi {
             .status(HttpStatus.OK)
             .body(updateCount);
     }
+
+    @Override
+    @GetMapping("/v1/classroom/info")
+    public ResponseEntity<ClassroomInfoResponse> getInfo(@RequestParam Long classroomId) {
+        ClassroomInfoResponse classroomInfo = classroomService.getClassroomInfo(classroomId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(classroomInfo);
+    }
+
 }
 

--- a/src/main/java/soma/edupimeta/classroom/ClassroomController.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
+import soma.edupimeta.classroom.account.models.ActionInitRequest;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.ClassroomService;
@@ -42,11 +42,11 @@ public class ClassroomController implements ClassroomOpenApi {
             .body(myClassroomsResponse);
     }
 
-    @PostMapping("/v1/classroom/action/initialization")
-    public ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitializeRequest actionInitializeRequest) {
-        log.info("Initial classroom id: {}", actionInitializeRequest.getClassroomId());
+    @PostMapping("/v1/classroom/action/init")
+    public ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitRequest actionInitRequest) {
+        log.info("Init classroom id: {}", actionInitRequest.getClassroomId());
         long updateCount = classroomService.initAllActionStatusBy(
-            actionInitializeRequest.getClassroomId()
+            actionInitRequest.getClassroomId()
         );
 
         return ResponseEntity

--- a/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
-import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
+import soma.edupimeta.classroom.account.models.ActionInitRequest;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.domain.Classroom;
@@ -33,5 +33,5 @@ public interface ClassroomOpenApi {
         @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitializeRequest actionInitializeRequest);
+    ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitRequest actionInitializeRequest);
 }

--- a/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
@@ -33,5 +33,5 @@ public interface ClassroomOpenApi {
         @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest);
+    ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitializeRequest actionInitializeRequest);
 }

--- a/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
@@ -5,10 +5,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
-import soma.edupimeta.classroom.models.MyClassroomsResponse;
+import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.domain.Classroom;
 
 @Tag(name = "Classroom", description = "Classroom API")
@@ -24,5 +25,5 @@ public interface ClassroomOpenApi {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "클래스룸 조회 성공", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<MyClassroomsResponse> getMyClassrooms(Long accountId);
+    ResponseEntity<List<MyClassroomResponse>> getMyClassrooms(Long accountId);
 }

--- a/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.domain.Classroom;
@@ -26,4 +27,11 @@ public interface ClassroomOpenApi {
         @ApiResponse(responseCode = "200", description = "클래스룸 조회 성공", content = @Content(mediaType = "application/json")),
     })
     ResponseEntity<List<MyClassroomResponse>> getMyClassrooms(Long accountId);
+
+    @Operation(summary = "클래스룸에 포함된 계정의 진척도 상태 초기화", description = "클래스룸에 포함된 계정의 진척도 상태 진행중으로 모두 초기화")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest);
 }

--- a/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import soma.edupimeta.classroom.account.models.ActionInitRequest;
+import soma.edupimeta.classroom.models.ClassroomInfoResponse;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.domain.Classroom;
@@ -34,4 +36,11 @@ public interface ClassroomOpenApi {
         @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
     })
     ResponseEntity<Long> initActionStatusBy(@RequestBody ActionInitRequest actionInitializeRequest);
+
+    @Operation(summary = "클래스룸 이름과 포함된 계정의 action 정보 반환", description = "클래스룸 이름과 포함된 계정의 현재 action 정보 반환")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "정보를 불러오는데 성공헀습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "해당 클래스룸이 없습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<ClassroomInfoResponse> getInfo(@RequestParam Long classroomId);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -15,7 +15,6 @@ import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.ClassroomAccountService;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
-import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 
 @Slf4j
 @RestController
@@ -26,11 +25,11 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
 
     @Override
     @PostMapping("/v1/classroom/account")
-    public ResponseEntity<ClassroomAccount> registerClassroomAccount(
+    public ResponseEntity<ClassroomAccountResponse> registerClassroomAccount(
         @RequestBody CreateClassroomAccountRequest createClassroomAccountRequest
     ) {
-        ClassroomAccount classroomAccount = classroomAccountService.registerClassroomAccount(
-            createClassroomAccountRequest.getAccountId(),
+        ClassroomAccountResponse classroomAccount = classroomAccountService.registerClassroomAccount(
+            createClassroomAccountRequest.getEmail(),
             createClassroomAccountRequest.getClassroomId(),
             createClassroomAccountRequest.getRole()
         );

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -38,13 +38,15 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
 
     @Override
     @PostMapping("/v1/classroom/action/initialization")
-    public ResponseEntity<Void> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest) {
+    public ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest) {
         log.info("Initial classroom id: {}", actionInitializeRequest.getClassroomId());
-        classroomAccountService.initializeClassroomAccountActionStatus(actionInitializeRequest.getClassroomId());
+        long updateCount = classroomAccountService.initializeClassroomAccountActionStatus(
+            actionInitializeRequest.getClassroomId()
+        );
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .build();
+            .body(updateCount);
     }
 
     @Override

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -36,12 +36,11 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
             .body(classroomAccount);
     }
 
-    @Override
     @PostMapping("/v1/classroom/account/action")
-    public ResponseEntity<ActionStatus> changeClassroomAccountActionStatus(
+    public ResponseEntity<ActionStatus> changeActionStatus(
         @RequestBody ActionChangeRequest actionChangeRequest
     ) {
-        ActionStatus actionStatus = classroomAccountService.changeClassroomAccountActionStatus(
+        ActionStatus actionStatus = classroomAccountService.changeActionStatusBy(
             actionChangeRequest.getClassroomId(),
             actionChangeRequest.getAccountId(),
             actionChangeRequest.getAction()

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import soma.edupimeta.classroom.account.models.ActionChangeRequest;
-import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.ClassroomAccountService;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 
 @Slf4j
@@ -37,24 +37,11 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
     }
 
     @Override
-    @PostMapping("/v1/classroom/action/initialization")
-    public ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest) {
-        log.info("Initial classroom id: {}", actionInitializeRequest.getClassroomId());
-        long updateCount = classroomAccountService.initializeClassroomAccountActionStatus(
-            actionInitializeRequest.getClassroomId()
-        );
-
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(updateCount);
-    }
-
-    @Override
     @PostMapping("/v1/classroom/account/action")
-    public ResponseEntity<Void> changeClassroomAccountActionStatus(
+    public ResponseEntity<ActionStatus> changeClassroomAccountActionStatus(
         @RequestBody ActionChangeRequest actionChangeRequest
     ) {
-        classroomAccountService.changeClassroomAccountActionStatus(
+        ActionStatus actionStatus = classroomAccountService.changeClassroomAccountActionStatus(
             actionChangeRequest.getClassroomId(),
             actionChangeRequest.getAccountId(),
             actionChangeRequest.getAction()
@@ -62,9 +49,8 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .build();
+            .body(actionStatus);
     }
-
 
 }
 

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import soma.edupimeta.classroom.account.models.ActionChangeRequest;
+import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.ClassroomAccountService;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
@@ -33,6 +35,34 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
             .status(HttpStatus.OK)
             .body(classroomAccount);
     }
+
+    @Override
+    @PostMapping("/v1/classroom/action/initialization")
+    public ResponseEntity<Void> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest) {
+        log.info("Initial classroom id: {}", actionInitializeRequest.getClassroomId());
+        classroomAccountService.initializeClassroomAccountActionStatus(actionInitializeRequest.getClassroomId());
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .build();
+    }
+
+    @Override
+    @PostMapping("/v1/classroom/account/action")
+    public ResponseEntity<Void> changeClassroomAccountActionStatus(
+        @RequestBody ActionChangeRequest actionChangeRequest
+    ) {
+        classroomAccountService.changeClassroomAccountActionStatus(
+            actionChangeRequest.getClassroomId(),
+            actionChangeRequest.getAccountId(),
+            actionChangeRequest.getAction()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .build();
+    }
+
 
 }
 

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -1,13 +1,17 @@
 package soma.edupimeta.classroom.account;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import soma.edupimeta.classroom.account.models.ActionChangeRequest;
+import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.ClassroomAccountService;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
@@ -36,6 +40,18 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
             .body(classroomAccount);
     }
 
+    @Override
+    @GetMapping("/v1/classroom/account")
+    public ResponseEntity<List<ClassroomAccountResponse>> getClassroomAccountsBy(@RequestParam Long classroomId) {
+        List<ClassroomAccountResponse> classroomAccounts = classroomAccountService.getAllClassroomAccountsBy(
+            classroomId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(classroomAccounts);
+    }
+
+    @Override
     @PostMapping("/v1/classroom/account/action")
     public ResponseEntity<ActionStatus> changeActionStatus(
         @RequestBody ActionChangeRequest actionChangeRequest

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -13,7 +13,6 @@ import soma.edupimeta.classroom.account.models.ActionChangeRequest;
 import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
-import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 
 @Tag(name = "ClassroomAccount", description = "ClassroomAccount API")
 public interface ClassroomAccountOpenApi {
@@ -23,7 +22,7 @@ public interface ClassroomAccountOpenApi {
         @ApiResponse(responseCode = "200", description = "클래스룸 계정 등록에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "이미 등록된 계정입니다.", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<ClassroomAccount> registerClassroomAccount(
+    ResponseEntity<ClassroomAccountResponse> registerClassroomAccount(
         @RequestBody CreateClassroomAccountRequest createClassroomAccountRequest
     );
 

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -29,7 +29,7 @@ public interface ClassroomAccountOpenApi {
         @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<Void> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest);
+    ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest);
 
     @Operation(summary = "클래스룸 계정의 진척도 상태 변경", description = "클래스룸 계정의 진척도 상태를 완료, 도움으로 변환")
     @ApiResponses(value = {

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -5,9 +5,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import soma.edupimeta.classroom.account.models.ActionChangeRequest;
+import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
@@ -23,6 +26,13 @@ public interface ClassroomAccountOpenApi {
     ResponseEntity<ClassroomAccount> registerClassroomAccount(
         @RequestBody CreateClassroomAccountRequest createClassroomAccountRequest
     );
+
+    @Operation(summary = "클래스룸 아이디로 포함된 모든 회원 조회", description = "클래스룸 아이디로 포함된 모든 회원 조회하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "클래스룸 조회에 성공했습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "클래스룸이 존재하지 않습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<List<ClassroomAccountResponse>> getClassroomAccountsBy(@RequestParam Long classroomId);
 
     @Operation(summary = "클래스룸 계정의 진척도 상태 변경", description = "클래스룸 계정의 진척도 상태를 완료, 도움으로 변환")
     @ApiResponses(value = {

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -29,7 +29,7 @@ public interface ClassroomAccountOpenApi {
         @ApiResponse(responseCode = "200", description = "상태 변환에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "상태를 변경할 수 없습니다.", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<ActionStatus> changeClassroomAccountActionStatus(
+    ResponseEntity<ActionStatus> changeActionStatus(
         @RequestBody ActionChangeRequest actionChangeRequest);
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -7,18 +7,35 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import soma.edupimeta.classroom.account.models.ActionChangeRequest;
+import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 
 @Tag(name = "ClassroomAccount", description = "ClassroomAccount API")
 public interface ClassroomAccountOpenApi {
 
-    @Operation(summary = "게스트 등록", description = "클래스룸에 게스트를 등록하는 API")
+    @Operation(summary = "클래스룸 계정 등록", description = "클래스룸에 계정을 등록하는 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "게스트 등록에 성공했습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "200", description = "클래스룸 계정 등록에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "이미 등록된 계정입니다.", content = @Content(mediaType = "application/json")),
     })
     ResponseEntity<ClassroomAccount> registerClassroomAccount(
         @RequestBody CreateClassroomAccountRequest createClassroomAccountRequest
     );
+
+    @Operation(summary = "클래스룸에 포함된 계정의 진척도 상태 초기화", description = "클래스룸에 포함된 계정의 진척도 상태 진행중으로 모두 초기화")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<Void> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest);
+
+    @Operation(summary = "클래스룸 계정의 진척도 상태 변경", description = "클래스룸 계정의 진척도 상태를 완료, 도움으로 변환")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "상태 변환에 성공했습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "상태를 변경할 수 없습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<Void> changeClassroomAccountActionStatus(@RequestBody ActionChangeRequest actionChangeRequest);
+
 }

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -8,8 +8,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import soma.edupimeta.classroom.account.models.ActionChangeRequest;
-import soma.edupimeta.classroom.account.models.ActionInitializeRequest;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 
 @Tag(name = "ClassroomAccount", description = "ClassroomAccount API")
@@ -24,18 +24,12 @@ public interface ClassroomAccountOpenApi {
         @RequestBody CreateClassroomAccountRequest createClassroomAccountRequest
     );
 
-    @Operation(summary = "클래스룸에 포함된 계정의 진척도 상태 초기화", description = "클래스룸에 포함된 계정의 진척도 상태 진행중으로 모두 초기화")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),
-        @ApiResponse(responseCode = "400", description = "초기화하는데 실패했습니다.", content = @Content(mediaType = "application/json")),
-    })
-    ResponseEntity<Long> initialization(@RequestBody ActionInitializeRequest actionInitializeRequest);
-
     @Operation(summary = "클래스룸 계정의 진척도 상태 변경", description = "클래스룸 계정의 진척도 상태를 완료, 도움으로 변환")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "상태 변환에 성공했습니다.", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "400", description = "상태를 변경할 수 없습니다.", content = @Content(mediaType = "application/json")),
     })
-    ResponseEntity<Void> changeClassroomAccountActionStatus(@RequestBody ActionChangeRequest actionChangeRequest);
+    ResponseEntity<ActionStatus> changeClassroomAccountActionStatus(
+        @RequestBody ActionChangeRequest actionChangeRequest);
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
+++ b/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
@@ -6,7 +6,8 @@ import soma.edupimeta.web.exception.ErrorEnum;
 public enum ClassroomAccountErrorEnum implements ErrorEnum {
     // 400
     ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "DB-400201", "클래스룸에 이미 참여되어 있습니다."),
-    CAN_NOT_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400202", "상태를 반영할 수 없습니다.");
+    CAN_NOT_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400202", "행동를 변경할 수 없습니다."),
+    ALREADY_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400203", "이미 동일한 행동입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
+++ b/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
@@ -6,8 +6,11 @@ import soma.edupimeta.web.exception.ErrorEnum;
 public enum ClassroomAccountErrorEnum implements ErrorEnum {
     // 400
     ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "DB-400201", "클래스룸에 이미 참여되어 있습니다."),
-    CAN_NOT_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400202", "행동를 변경할 수 없습니다."),
-    ALREADY_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400203", "이미 동일한 행동입니다.");
+    ALREADY_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400202", "이미 동일한 행동입니다."),
+    HOST_CAN_NOT_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400203", "클래스룸을 생성한 사람은 행동을 수정할 수 없습니다."),
+
+    //404
+    CLASSROOM_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "DB-404200", "해당 클래스룸 계정을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
+++ b/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
@@ -6,8 +6,7 @@ import soma.edupimeta.web.exception.ErrorEnum;
 public enum ClassroomAccountErrorEnum implements ErrorEnum {
     // 400
     ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "DB-400201", "클래스룸에 이미 참여되어 있습니다."),
-
-    ;
+    CAN_NOT_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400202", "상태를 반영할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
+++ b/src/main/java/soma/edupimeta/classroom/account/exception/ClassroomAccountErrorEnum.java
@@ -8,6 +8,7 @@ public enum ClassroomAccountErrorEnum implements ErrorEnum {
     ALREADY_REGISTER(HttpStatus.BAD_REQUEST, "DB-400201", "클래스룸에 이미 참여되어 있습니다."),
     ALREADY_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400202", "이미 동일한 행동입니다."),
     HOST_CAN_NOT_UPDATE_ACTION_STATUS(HttpStatus.BAD_REQUEST, "DB-400203", "클래스룸을 생성한 사람은 행동을 수정할 수 없습니다."),
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "DB-400204", "잘못된 값이 들어왔습니다."),
 
     //404
     CLASSROOM_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "DB-404200", "해당 클래스룸 계정을 찾을 수 없습니다.");

--- a/src/main/java/soma/edupimeta/classroom/account/models/ActionChangeRequest.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/ActionChangeRequest.java
@@ -1,0 +1,14 @@
+package soma.edupimeta.classroom.account.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+
+@Getter
+@NoArgsConstructor
+public class ActionChangeRequest {
+
+    private Long classroomId;
+    private Long accountId;
+    private ActionStatus action;
+}

--- a/src/main/java/soma/edupimeta/classroom/account/models/ActionInitRequest.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/ActionInitRequest.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ActionInitializeRequest {
+public class ActionInitRequest {
 
     private Long classroomId;
 }

--- a/src/main/java/soma/edupimeta/classroom/account/models/ActionInitializeRequest.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/ActionInitializeRequest.java
@@ -1,0 +1,11 @@
+package soma.edupimeta.classroom.account.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ActionInitializeRequest {
+
+    private Long classroomId;
+}

--- a/src/main/java/soma/edupimeta/classroom/account/models/ClassroomAccountResponse.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/ClassroomAccountResponse.java
@@ -1,0 +1,31 @@
+package soma.edupimeta.classroom.account.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
+
+@Getter
+@NoArgsConstructor
+public class ClassroomAccountResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private ActionStatus status;
+    private ClassroomAccountRole role;
+
+    public ClassroomAccountResponse(
+        Long id,
+        String email,
+        String name,
+        int status,
+        ClassroomAccountRole role
+    ) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.status = ActionStatus.fromValue(status);
+        this.role = role;
+    }
+}

--- a/src/main/java/soma/edupimeta/classroom/account/models/ClassroomAccountResponse.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/ClassroomAccountResponse.java
@@ -2,7 +2,9 @@ package soma.edupimeta.classroom.account.models;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import soma.edupimeta.account.service.domain.Account;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 
 @Getter
@@ -27,5 +29,13 @@ public class ClassroomAccountResponse {
         this.name = name;
         this.status = ActionStatus.fromValue(status);
         this.role = role;
+    }
+
+    public ClassroomAccountResponse(Account account, ClassroomAccount classroomAccount) {
+        this.id = classroomAccount.getId();
+        this.email = account.getEmail();
+        this.name = account.getName();
+        this.status = classroomAccount.getActionStatus();
+        this.role = classroomAccount.getRole();
     }
 }

--- a/src/main/java/soma/edupimeta/classroom/account/models/CreateClassroomAccountRequest.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/CreateClassroomAccountRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 
 @Getter
@@ -13,18 +12,10 @@ import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 public class CreateClassroomAccountRequest {
 
     @NotNull
-    private Long accountId;
+    private String email;
     @NotNull
     private Long classroomId;
     @NotNull
     private ClassroomAccountRole role;
-
-    public ClassroomAccount toEntity(ClassroomAccountRole role) {
-        return ClassroomAccount.builder()
-            .accountId(accountId)
-            .classroomId(classroomId)
-            .role(role)
-            .build();
-    }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
@@ -53,28 +53,17 @@ public class ClassroomAccountService {
             throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
         }
 
-        if (isHost(classroomId, accountId)) {
-            throw new ClassroomAccountException(ClassroomAccountErrorEnum.CAN_NOT_UPDATE_ACTION_STATUS);
-        }
+        ClassroomAccount classroomAccount = getClassroomAccount(classroomId, accountId);
 
-        boolean isUpdated = classroomAccountRepository.updateActionStatusByClassroomIdAndAccountId(
-            classroomId,
-            accountId,
-            actionStatus
-        );
-
-        if (!isUpdated) {
-            throw new ClassroomAccountException(ClassroomAccountErrorEnum.ALREADY_UPDATE_ACTION_STATUS);
+        if (classroomAccount.getRole() == ClassroomAccountRole.HOST) {
+            throw new ClassroomAccountException(ClassroomAccountErrorEnum.HOST_CAN_NOT_UPDATE_ACTION_STATUS);
         }
+        
+        classroomAccount.updateActionStatus(actionStatus);
     }
 
     private boolean isExistsClassroom(Long classroomId) {
         return !classroomRepository.existsById(classroomId);
-    }
-
-    private boolean isHost(Long classroomId, Long accountId) {
-        return classroomAccountRepository.existsByAccountIdAndClassroomIdAndRole(accountId, classroomId,
-            ClassroomAccountRole.HOST);
     }
 
     private boolean isDuplicate(Long accountId, Long classroomId) {
@@ -83,6 +72,11 @@ public class ClassroomAccountService {
 
     private ClassroomAccount addClassroomAccount(ClassroomAccount classroomAccount) {
         return classroomAccountRepository.save(classroomAccount);
+    }
+
+    private ClassroomAccount getClassroomAccount(Long classroomId, Long accountId) {
+        return classroomAccountRepository.findByClassroomIdAndAccountId(classroomId, accountId)
+            .orElseThrow(() -> new ClassroomAccountException(ClassroomAccountErrorEnum.CLASSROOM_ACCOUNT_NOT_FOUND));
     }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
@@ -33,22 +33,15 @@ public class ClassroomAccountService {
         ClassroomAccount classroomAccount = ClassroomAccount.builder()
             .accountId(accountId)
             .classroomId(classroomId)
-            .actionStatus(ActionStatus.ING.getType())
+            .actionStatus(ActionStatus.ING.getValue())
             .role(role)
             .build();
 
         return addClassroomAccount(classroomAccount);
     }
 
-    public Long initializeClassroomAccountActionStatus(Long classroomId) {
-        if (isExistsClassroom(classroomId)) {
-            throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
-        }
-
-        return classroomAccountRepository.updateActionStatusForClassroom(classroomId);
-    }
-
-    public void changeClassroomAccountActionStatus(Long classroomId, Long accountId, ActionStatus actionStatus) {
+    public ActionStatus changeClassroomAccountActionStatus(Long classroomId, Long accountId,
+        ActionStatus actionStatus) {
         if (isExistsClassroom(classroomId)) {
             throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
         }
@@ -58,8 +51,10 @@ public class ClassroomAccountService {
         if (classroomAccount.getRole() == ClassroomAccountRole.HOST) {
             throw new ClassroomAccountException(ClassroomAccountErrorEnum.HOST_CAN_NOT_UPDATE_ACTION_STATUS);
         }
-        
+
         classroomAccount.updateActionStatus(actionStatus);
+
+        return classroomAccount.getActionStatus();
     }
 
     private boolean isExistsClassroom(Long classroomId) {

--- a/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
@@ -40,8 +40,11 @@ public class ClassroomAccountService {
         return addClassroomAccount(classroomAccount);
     }
 
-    public ActionStatus changeClassroomAccountActionStatus(Long classroomId, Long accountId,
-        ActionStatus actionStatus) {
+    public ActionStatus changeActionStatusBy(
+        Long classroomId,
+        Long accountId,
+        ActionStatus actionStatus
+    ) {
         if (isExistsClassroom(classroomId)) {
             throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
         }

--- a/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
@@ -1,10 +1,12 @@
 package soma.edupimeta.classroom.account.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soma.edupimeta.classroom.account.exception.ClassroomAccountErrorEnum;
 import soma.edupimeta.classroom.account.exception.ClassroomAccountException;
+import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
@@ -38,6 +40,10 @@ public class ClassroomAccountService {
             .build();
 
         return addClassroomAccount(classroomAccount);
+    }
+
+    public List<ClassroomAccountResponse> getAllClassroomAccountsBy(Long classroomId) {
+        return classroomAccountRepository.findByClassroomId(classroomId);
     }
 
     public ActionStatus changeActionStatusBy(

--- a/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import soma.edupimeta.classroom.account.exception.ClassroomAccountErrorEnum;
 import soma.edupimeta.classroom.account.exception.ClassroomAccountException;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 import soma.edupimeta.classroom.account.service.repository.ClassroomAccountRepository;
@@ -30,10 +31,31 @@ public class ClassroomAccountService {
         ClassroomAccount classroomAccount = ClassroomAccount.builder()
             .accountId(accountId)
             .classroomId(classroomId)
+            .actionStatus(ActionStatus.ING.getType())
             .role(role)
             .build();
 
         return addClassroomAccount(classroomAccount);
+    }
+
+    public void initializeClassroomAccountActionStatus(Long classroomId) {
+        boolean isUpdated = classroomAccountRepository.updateActionStatusForClassroom(classroomId);
+
+        if (!isUpdated) {
+            throw new ClassroomAccountException(ClassroomAccountErrorEnum.CAN_NOT_UPDATE_ACTION_STATUS);
+        }
+    }
+
+    public void changeClassroomAccountActionStatus(Long classroomId, Long accountId, ActionStatus actionStatus) {
+        boolean isUpdated = classroomAccountRepository.updateActionStatusByClassroomIdAndAccountId(
+            classroomId,
+            accountId,
+            actionStatus
+        );
+
+        if (!isUpdated) {
+            throw new ClassroomAccountException(ClassroomAccountErrorEnum.CAN_NOT_UPDATE_ACTION_STATUS);
+        }
     }
 
     private boolean isExistsClassroom(Long classroomId) {

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ActionStatus.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ActionStatus.java
@@ -1,14 +1,33 @@
 package soma.edupimeta.classroom.account.service.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
+import soma.edupimeta.classroom.account.exception.ClassroomAccountErrorEnum;
+import soma.edupimeta.classroom.account.exception.ClassroomAccountException;
 
 @Getter
 public enum ActionStatus {
     ING(0), HELP(1), COMPLETE(2);
 
-    private final int type;
+    private final int value;
 
-    ActionStatus(int type) {
-        this.type = type;
+    ActionStatus(int value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static ActionStatus fromValue(int value) {
+        for (ActionStatus actionStatus : ActionStatus.values()) {
+            if (actionStatus.getValue() == value) {
+                return actionStatus;
+            }
+        }
+        throw new ClassroomAccountException(ClassroomAccountErrorEnum.INVALID_VALUE);
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
     }
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ActionStatus.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ActionStatus.java
@@ -1,0 +1,14 @@
+package soma.edupimeta.classroom.account.service.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ActionStatus {
+    ING(0), HELP(1), COMPLETE(2);
+
+    private final int type;
+
+    ActionStatus(int type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
@@ -10,9 +10,11 @@ import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
+@Getter
 @Entity
 @NoArgsConstructor
 public class ClassroomAccount {

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
@@ -29,6 +29,9 @@ public class ClassroomAccount {
     private Long classroomId;
 
     @NotNull
+    private int actionStatus;
+
+    @NotNull
     @Enumerated(EnumType.STRING)
     private ClassroomAccountRole role;
 
@@ -37,9 +40,10 @@ public class ClassroomAccount {
     private LocalDateTime createdAt;
 
     @Builder
-    public ClassroomAccount(Long accountId, Long classroomId, ClassroomAccountRole role) {
+    public ClassroomAccount(Long accountId, Long classroomId, int actionStatus, ClassroomAccountRole role) {
         this.accountId = accountId;
         this.classroomId = classroomId;
+        this.actionStatus = actionStatus;
         this.role = role;
     }
 

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
@@ -50,7 +50,11 @@ public class ClassroomAccount {
     }
 
     public void updateActionStatus(ActionStatus actionStatus) {
-        this.actionStatus = actionStatus.getType();
+        this.actionStatus = actionStatus.getValue();
+    }
+
+    public ActionStatus getActionStatus() {
+        return ActionStatus.fromValue(actionStatus);
     }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccount.java
@@ -49,4 +49,8 @@ public class ClassroomAccount {
         this.role = role;
     }
 
+    public void updateActionStatus(ActionStatus actionStatus) {
+        this.actionStatus = actionStatus.getType();
+    }
+
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccountRole.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccountRole.java
@@ -1,6 +1,29 @@
 package soma.edupimeta.classroom.account.service.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum ClassroomAccountRole {
-    HOST,
-    GUEST
+    HOST(1), GUEST(2);
+
+    private final int value;
+
+    ClassroomAccountRole(int value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static ClassroomAccountRole fromValue(int value) {
+        for (ClassroomAccountRole role : ClassroomAccountRole.values()) {
+            if (role.getValue() == value) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("Invalid value for ClassroomAccountRole: " + value);
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
+    }
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccountRole.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/domain/ClassroomAccountRole.java
@@ -2,6 +2,8 @@ package soma.edupimeta.classroom.account.service.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import soma.edupimeta.classroom.account.exception.ClassroomAccountErrorEnum;
+import soma.edupimeta.classroom.account.exception.ClassroomAccountException;
 
 public enum ClassroomAccountRole {
     HOST(1), GUEST(2);
@@ -19,7 +21,7 @@ public enum ClassroomAccountRole {
                 return role;
             }
         }
-        throw new IllegalArgumentException("Invalid value for ClassroomAccountRole: " + value);
+        throw new ClassroomAccountException(ClassroomAccountErrorEnum.INVALID_VALUE);
     }
 
     @JsonValue

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
@@ -1,0 +1,10 @@
+package soma.edupimeta.classroom.account.service.repository;
+
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+
+public interface ClassroomAccountQueryRepository {
+
+    Boolean updateActionStatusForClassroom(Long classroomId);
+
+    Boolean updateActionStatusByClassroomIdAndAccountId(Long classroomId, Long accountId, ActionStatus actionStatus);
+}

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
@@ -4,7 +4,7 @@ import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 
 public interface ClassroomAccountQueryRepository {
 
-    Boolean updateActionStatusForClassroom(Long classroomId);
+    Long updateActionStatusForClassroom(Long classroomId);
 
     Boolean updateActionStatusByClassroomIdAndAccountId(Long classroomId, Long accountId, ActionStatus actionStatus);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
@@ -1,7 +1,11 @@
 package soma.edupimeta.classroom.account.service.repository;
 
+import java.util.List;
+import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
+
 public interface ClassroomAccountQueryRepository {
 
     Long updateActionStatusForClassroom(Long classroomId);
 
+    List<ClassroomAccountResponse> findByClassroomId(Long classroomId);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepository.java
@@ -1,10 +1,7 @@
 package soma.edupimeta.classroom.account.service.repository;
 
-import soma.edupimeta.classroom.account.service.domain.ActionStatus;
-
 public interface ClassroomAccountQueryRepository {
 
     Long updateActionStatusForClassroom(Long classroomId);
 
-    Boolean updateActionStatusByClassroomIdAndAccountId(Long classroomId, Long accountId, ActionStatus actionStatus);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
@@ -14,14 +14,16 @@ public class ClassroomAccountQueryRepositoryImpl implements ClassroomAccountQuer
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Boolean updateActionStatusForClassroom(Long classroomId) {
-        long updatedCount = queryFactory
+    public Long updateActionStatusForClassroom(Long classroomId) {
+        return queryFactory
             .update(classroomAccount)
             .set(classroomAccount.actionStatus, ActionStatus.ING.getType())
-            .where(classroomAccount.id.eq(classroomId))
+            .where(
+                classroomAccount.classroomId.eq(classroomId),
+                classroomAccount.actionStatus.ne(ActionStatus.ING.getType())
+            )
             .execute();
 
-        return updatedCount > 0;
     }
 
     @Override

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
@@ -1,11 +1,16 @@
 package soma.edupimeta.classroom.account.service.repository;
 
+import static soma.edupimeta.account.service.domain.QAccount.account;
 import static soma.edupimeta.classroom.account.service.domain.QClassroomAccount.classroomAccount;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,6 +29,28 @@ public class ClassroomAccountQueryRepositoryImpl implements ClassroomAccountQuer
             )
             .execute();
 
+    }
+
+    @Override
+    public List<ClassroomAccountResponse> findByClassroomId(Long classroomId) {
+        return queryFactory
+            .select(Projections.constructor(
+                ClassroomAccountResponse.class,
+                classroomAccount.id,
+                account.email,
+                account.name,
+                classroomAccount.actionStatus,
+                classroomAccount.role
+
+            ))
+            .from(classroomAccount)
+            .leftJoin(account)
+            .on(classroomAccount.accountId.eq(account.id))
+            .where(
+                classroomAccount.classroomId.eq(classroomId),
+                classroomAccount.role.eq(ClassroomAccountRole.GUEST)
+            )
+            .fetch();
     }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
@@ -26,22 +26,4 @@ public class ClassroomAccountQueryRepositoryImpl implements ClassroomAccountQuer
 
     }
 
-    @Override
-    public Boolean updateActionStatusByClassroomIdAndAccountId(
-        Long classroomId,
-        Long accountId,
-        ActionStatus actionStatus
-    ) {
-        long updatedCount = queryFactory
-            .update(classroomAccount)
-            .set(classroomAccount.actionStatus, actionStatus.getType())
-            .where(
-                classroomAccount.classroomId.eq(classroomId),
-                classroomAccount.accountId.eq(accountId)
-            )
-            .execute();
-
-        return updatedCount > 0;
-    }
-
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
@@ -17,10 +17,10 @@ public class ClassroomAccountQueryRepositoryImpl implements ClassroomAccountQuer
     public Long updateActionStatusForClassroom(Long classroomId) {
         return queryFactory
             .update(classroomAccount)
-            .set(classroomAccount.actionStatus, ActionStatus.ING.getType())
+            .set(classroomAccount.actionStatus, ActionStatus.ING.getValue())
             .where(
                 classroomAccount.classroomId.eq(classroomId),
-                classroomAccount.actionStatus.ne(ActionStatus.ING.getType())
+                classroomAccount.actionStatus.ne(ActionStatus.ING.getValue())
             )
             .execute();
 

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountQueryRepositoryImpl.java
@@ -1,0 +1,45 @@
+package soma.edupimeta.classroom.account.service.repository;
+
+import static soma.edupimeta.classroom.account.service.domain.QClassroomAccount.classroomAccount;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+
+@Repository
+@RequiredArgsConstructor
+public class ClassroomAccountQueryRepositoryImpl implements ClassroomAccountQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Boolean updateActionStatusForClassroom(Long classroomId) {
+        long updatedCount = queryFactory
+            .update(classroomAccount)
+            .set(classroomAccount.actionStatus, ActionStatus.ING.getType())
+            .where(classroomAccount.id.eq(classroomId))
+            .execute();
+
+        return updatedCount > 0;
+    }
+
+    @Override
+    public Boolean updateActionStatusByClassroomIdAndAccountId(
+        Long classroomId,
+        Long accountId,
+        ActionStatus actionStatus
+    ) {
+        long updatedCount = queryFactory
+            .update(classroomAccount)
+            .set(classroomAccount.actionStatus, actionStatus.getType())
+            .where(
+                classroomAccount.classroomId.eq(classroomId),
+                classroomAccount.accountId.eq(accountId)
+            )
+            .execute();
+
+        return updatedCount > 0;
+    }
+
+}

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
@@ -1,9 +1,9 @@
 package soma.edupimeta.classroom.account.service.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
-import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 
 @Repository
 public interface ClassroomAccountRepository
@@ -11,5 +11,5 @@ public interface ClassroomAccountRepository
 
     boolean existsByAccountIdAndClassroomId(Long accountId, Long classroomId);
 
-    boolean existsByAccountIdAndClassroomIdAndRole(Long accountId, Long classroomId, ClassroomAccountRole role);
+    Optional<ClassroomAccount> findByClassroomIdAndAccountId(Long classroomId, Long accountId);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
@@ -3,6 +3,7 @@ package soma.edupimeta.classroom.account.service.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
+import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 
 @Repository
 public interface ClassroomAccountRepository
@@ -10,4 +11,5 @@ public interface ClassroomAccountRepository
 
     boolean existsByAccountIdAndClassroomId(Long accountId, Long classroomId);
 
+    boolean existsByAccountIdAndClassroomIdAndRole(Long accountId, Long classroomId, ClassroomAccountRole role);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
@@ -5,7 +5,8 @@ import org.springframework.stereotype.Repository;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
 
 @Repository
-public interface ClassroomAccountRepository extends JpaRepository<ClassroomAccount, Long> {
+public interface ClassroomAccountRepository
+    extends JpaRepository<ClassroomAccount, Long>, ClassroomAccountQueryRepository {
 
     boolean existsByAccountIdAndClassroomId(Long accountId, Long classroomId);
 

--- a/src/main/java/soma/edupimeta/classroom/models/ClassroomActionInfo.java
+++ b/src/main/java/soma/edupimeta/classroom/models/ClassroomActionInfo.java
@@ -1,0 +1,18 @@
+package soma.edupimeta.classroom.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.edupimeta.classroom.account.service.domain.ActionStatus;
+
+@Getter
+@NoArgsConstructor
+public class ClassroomActionInfo {
+
+    private String name;
+    private Long count;
+
+    public ClassroomActionInfo(int actionValue, Long count) {
+        this.name = ActionStatus.fromValue(actionValue).name();
+        this.count = count;
+    }
+}

--- a/src/main/java/soma/edupimeta/classroom/models/ClassroomInfoResponse.java
+++ b/src/main/java/soma/edupimeta/classroom/models/ClassroomInfoResponse.java
@@ -1,0 +1,18 @@
+package soma.edupimeta.classroom.models;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ClassroomInfoResponse {
+
+    private String className;
+    private List<ClassroomActionInfo> totalActionInfo;
+
+    public ClassroomInfoResponse(String className, List<ClassroomActionInfo> totalActionInfo) {
+        this.className = className;
+        this.totalActionInfo = totalActionInfo;
+    }
+}

--- a/src/main/java/soma/edupimeta/classroom/models/MyClassroomResponse.java
+++ b/src/main/java/soma/edupimeta/classroom/models/MyClassroomResponse.java
@@ -2,6 +2,7 @@ package soma.edupimeta.classroom.models;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 
 @Getter
 @NoArgsConstructor
@@ -9,11 +10,13 @@ public class MyClassroomResponse {
 
     private Long id;
     private String name;
+    private ClassroomAccountRole role;
     private Long totalPeople;
 
-    public MyClassroomResponse(Long id, String name, Long totalPeople) {
+    public MyClassroomResponse(Long id, String name, ClassroomAccountRole role, Long totalPeople) {
         this.id = id;
         this.name = name;
+        this.role = role;
         this.totalPeople = totalPeople;
     }
 }

--- a/src/main/java/soma/edupimeta/classroom/models/MyClassroomsResponse.java
+++ b/src/main/java/soma/edupimeta/classroom/models/MyClassroomsResponse.java
@@ -8,11 +8,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MyClassroomsResponse {
 
-    private List<MyClassroomResponse> host;
-    private List<MyClassroomResponse> guest;
+    private List<MyClassroomResponse> myClassrooms;
 
-    public MyClassroomsResponse(List<MyClassroomResponse> host, List<MyClassroomResponse> guest) {
-        this.host = host;
-        this.guest = guest;
+    public MyClassroomsResponse(List<MyClassroomResponse> myClassrooms) {
+        this.myClassrooms = myClassrooms;
     }
 }

--- a/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
+++ b/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
@@ -25,22 +25,19 @@ public class ClassroomService {
     private final ClassroomAccountRepository classroomAccountRepository;
 
     public Classroom createClassroom(CreateClassroomRequest createClassroomRequest) {
-        // AccountId가 같고 Leader로 참여한 classroom 중에 name이 일치하는 것이 있으면
         if (isDuplicatedClassroomName(createClassroomRequest)) {
             throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NAME_DUPLICATE);
         }
 
-        // 클래스룸 생성
-        Classroom savedClassroom = classroomRepository.save(createClassroomRequest.toEntity());
+        Classroom savedClassroom = addClassroom(createClassroomRequest);
 
-        // 호스트 생성
         ClassroomAccount classroomAccount = ClassroomAccount.builder()
             .accountId(createClassroomRequest.getAccountId())
             .classroomId(savedClassroom.getId())
             .role(ClassroomAccountRole.HOST)
             .build();
 
-        classroomAccountRepository.save(classroomAccount);
+        addClassroomAccount(classroomAccount);
 
         return savedClassroom;
     }
@@ -51,15 +48,15 @@ public class ClassroomService {
             throw new AccountException(AccountErrorEnum.EMAIL_NOT_MATCH);
         }
 
-        return classroomRepository.findMyClassrooms(accountId);
+        return findMyClassroomsBy(accountId);
     }
 
-    public Long initializeClassroomAccountActionStatus(Long classroomId) {
-        if (isExistsClassroom(classroomId)) {
+    public Long initAllActionStatusBy(Long classroomId) {
+        if (isExistClassroom(classroomId)) {
             throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
         }
 
-        return classroomAccountRepository.updateActionStatusForClassroom(classroomId);
+        return initActionStatusBy(classroomId);
     }
 
     private Boolean isDuplicatedClassroomName(CreateClassroomRequest createClassroomRequest) {
@@ -69,8 +66,24 @@ public class ClassroomService {
         );
     }
 
-    private boolean isExistsClassroom(Long classroomId) {
-        return !classroomRepository.existsById(classroomId);
+    private Classroom addClassroom(CreateClassroomRequest createClassroomRequest) {
+        return classroomRepository.save(createClassroomRequest.toEntity());
+    }
+
+    private void addClassroomAccount(ClassroomAccount classroomAccount) {
+        classroomAccountRepository.save(classroomAccount);
+    }
+
+    private List<MyClassroomResponse> findMyClassroomsBy(Long accountId) {
+        return classroomRepository.findMyClassrooms(accountId);
+    }
+
+    private boolean isExistClassroom(Long classroomId) {
+        return classroomRepository.existsById(classroomId);
+    }
+
+    private Long initActionStatusBy(Long classroomId) {
+        return classroomAccountRepository.updateActionStatusForClassroom(classroomId);
     }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
+++ b/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
@@ -13,7 +13,6 @@ import soma.edupimeta.classroom.exception.ClassroomErrorEnum;
 import soma.edupimeta.classroom.exception.ClassroomException;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
-import soma.edupimeta.classroom.models.MyClassroomsResponse;
 import soma.edupimeta.classroom.service.domain.Classroom;
 import soma.edupimeta.classroom.service.repository.ClassroomRepository;
 
@@ -47,22 +46,12 @@ public class ClassroomService {
     }
 
     @Transactional(readOnly = true)
-    public MyClassroomsResponse getMyClassrooms(Long accountId) {
+    public List<MyClassroomResponse> getMyClassrooms(Long accountId) {
         if (accountId == null) {
             throw new AccountException(AccountErrorEnum.EMAIL_NOT_MATCH);
         }
 
-        List<MyClassroomResponse> hosts = classroomRepository.findMyClassroomByClassroomAccountRole(
-            accountId,
-            ClassroomAccountRole.HOST
-        );
-
-        List<MyClassroomResponse> guests = classroomRepository.findMyClassroomByClassroomAccountRole(
-            accountId,
-            ClassroomAccountRole.GUEST
-        );
-
-        return new MyClassroomsResponse(hosts, guests);
+        return classroomRepository.findMyClassrooms(accountId);
     }
 
     private Boolean isDuplicatedClassroomName(CreateClassroomRequest createClassroomRequest) {

--- a/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
+++ b/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
@@ -11,6 +11,8 @@ import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 import soma.edupimeta.classroom.account.service.repository.ClassroomAccountRepository;
 import soma.edupimeta.classroom.exception.ClassroomErrorEnum;
 import soma.edupimeta.classroom.exception.ClassroomException;
+import soma.edupimeta.classroom.models.ClassroomActionInfo;
+import soma.edupimeta.classroom.models.ClassroomInfoResponse;
 import soma.edupimeta.classroom.models.CreateClassroomRequest;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 import soma.edupimeta.classroom.service.domain.Classroom;
@@ -57,6 +59,18 @@ public class ClassroomService {
         }
 
         return initActionStatusBy(classroomId);
+    }
+
+    @Transactional(readOnly = true)
+    public ClassroomInfoResponse getClassroomInfo(Long classroomId) {
+
+        Classroom classroom = classroomRepository.findClassroomById(classroomId).orElseThrow(
+            () -> new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND)
+        );
+
+        List<ClassroomActionInfo> classroomActionInfos = classroomRepository.findClassroomInfo(classroomId);
+
+        return new ClassroomInfoResponse(classroom.getName(), classroomActionInfos);
     }
 
     private Boolean isDuplicatedClassroomName(CreateClassroomRequest createClassroomRequest) {

--- a/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
+++ b/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
@@ -54,11 +54,23 @@ public class ClassroomService {
         return classroomRepository.findMyClassrooms(accountId);
     }
 
+    public Long initializeClassroomAccountActionStatus(Long classroomId) {
+        if (isExistsClassroom(classroomId)) {
+            throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
+        }
+
+        return classroomAccountRepository.updateActionStatusForClassroom(classroomId);
+    }
+
     private Boolean isDuplicatedClassroomName(CreateClassroomRequest createClassroomRequest) {
         return classroomRepository.existsHostClassroomByAccountIdAndName(
             createClassroomRequest.getAccountId(),
             createClassroomRequest.getName()
         );
+    }
+
+    private boolean isExistsClassroom(Long classroomId) {
+        return !classroomRepository.existsById(classroomId);
     }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepository.java
@@ -2,6 +2,7 @@ package soma.edupimeta.classroom.service.repository;
 
 import java.util.List;
 import org.springframework.stereotype.Repository;
+import soma.edupimeta.classroom.models.ClassroomActionInfo;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 
 @Repository
@@ -11,4 +12,5 @@ public interface ClassroomQueryRepository {
 
     List<MyClassroomResponse> findMyClassrooms(Long accountId);
 
+    List<ClassroomActionInfo> findClassroomInfo(Long classroomId);
 }

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepository.java
@@ -2,7 +2,6 @@ package soma.edupimeta.classroom.service.repository;
 
 import java.util.List;
 import org.springframework.stereotype.Repository;
-import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 
 @Repository
@@ -10,6 +9,6 @@ public interface ClassroomQueryRepository {
 
     boolean existsHostClassroomByAccountIdAndName(Long accountId, String name);
 
-    List<MyClassroomResponse> findMyClassroomByClassroomAccountRole(Long accountId, ClassroomAccountRole role);
+    List<MyClassroomResponse> findMyClassrooms(Long accountId);
 
 }

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
@@ -17,6 +17,7 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    @Override
     public boolean existsHostClassroomByAccountIdAndName(Long accountId, String name) {
 
         Integer fetchOne = queryFactory
@@ -34,6 +35,7 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
         return fetchOne != null;
     }
 
+    @Override
     public List<MyClassroomResponse> findMyClassroomByClassroomAccountRole(Long accountId, ClassroomAccountRole role) {
         return queryFactory
             .select(Projections.constructor(

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
@@ -24,7 +24,7 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
             .selectOne()
             .from(classroomAccount)
             .leftJoin(classroom)
-            .on(classroomAccount.accountId.eq(classroom.id))
+            .on(classroomAccount.classroomId.eq(classroom.id))
             .where(
                 classroomAccount.accountId.eq(accountId),
                 classroomAccount.role.eq(ClassroomAccountRole.HOST),

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
@@ -36,21 +36,19 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
     }
 
     @Override
-    public List<MyClassroomResponse> findMyClassroomByClassroomAccountRole(Long accountId, ClassroomAccountRole role) {
+    public List<MyClassroomResponse> findMyClassrooms(Long accountId) {
         return queryFactory
             .select(Projections.constructor(
                 MyClassroomResponse.class,
                 classroom.id,
                 classroom.name,
+                classroomAccount.role,
                 classroomAccount.id.count().as("totalPeople")
             ))
             .from(classroom)
             .leftJoin(classroomAccount)
             .on(classroomAccount.classroomId.eq(classroom.id))
-            .where(
-                classroomAccount.accountId.eq(accountId),
-                classroomAccount.role.eq(role)
-            )
+            .where(classroomAccount.accountId.eq(accountId))
             .groupBy(classroom.id)
             .fetch();
     }

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccountRole;
+import soma.edupimeta.classroom.models.ClassroomActionInfo;
 import soma.edupimeta.classroom.models.MyClassroomResponse;
 
 @Repository
@@ -19,7 +20,6 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
 
     @Override
     public boolean existsHostClassroomByAccountIdAndName(Long accountId, String name) {
-
         Integer fetchOne = queryFactory
             .selectOne()
             .from(classroomAccount)
@@ -50,6 +50,25 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
             .on(classroomAccount.classroomId.eq(classroom.id))
             .where(classroomAccount.accountId.eq(accountId))
             .groupBy(classroom.id)
+            .fetch();
+    }
+
+    @Override
+    public List<ClassroomActionInfo> findClassroomInfo(Long classroomId) {
+        return queryFactory
+            .select(Projections.constructor(
+                ClassroomActionInfo.class,
+                classroomAccount.actionStatus,
+                classroomAccount.id.count().as("count")
+            ))
+            .from(classroom)
+            .leftJoin(classroomAccount)
+            .on(classroomAccount.classroomId.eq(classroom.id))
+            .where(
+                classroom.id.eq(classroomId),
+                classroomAccount.role.eq(ClassroomAccountRole.GUEST)
+            )
+            .groupBy(classroomAccount.actionStatus)
             .fetch();
     }
 }

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
@@ -47,7 +47,10 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
             .from(classroom)
             .leftJoin(classroomAccount)
             .on(classroomAccount.classroomId.eq(classroom.id))
-            .where(classroomAccount.role.eq(role))
+            .where(
+                classroomAccount.accountId.eq(accountId),
+                classroomAccount.role.eq(role)
+            )
             .groupBy(classroom.id)
             .fetch();
     }

--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomRepository.java
@@ -1,8 +1,10 @@
 package soma.edupimeta.classroom.service.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import soma.edupimeta.classroom.service.domain.Classroom;
 
 public interface ClassroomRepository extends JpaRepository<Classroom, Long>, ClassroomQueryRepository {
 
+    Optional<Classroom> findClassroomById(Long classroomId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #40 

## 📝 작업 내용

- classroomId를 기준으로 ActionStatus를 모두 0으로 초기화하는 기능
- classroomId, AccountId를 기준으로 ActionStatus를 수정하는 기능
- 나의 클래스룸 조회 json 수정

### 스크린샷 (선택)
초기기화
<img width="868" alt="스크린샷 2024-09-27 15 59 48" src="https://github.com/user-attachments/assets/fc1da0ad-2fc2-41eb-a0eb-c61a8f9060f7">

자신의 ActionStatus 업데이트
<img width="885" alt="스크린샷 2024-09-27 16 00 01" src="https://github.com/user-attachments/assets/4697301e-d7f8-43b6-8aad-d257bbfeff98">


## 💬 리뷰 요구사항(선택)

- 초기화는 update된 칼럼의 수를 리턴하도록 만들었습니다.