### PR TITLE
[#47]feat: 클래스룸 설정 - 클래스룸 삭제(클래스룸 계정도 같이)

### DIFF
--- a/src/main/java/soma/edupimeta/classroom/ClassroomController.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,6 +43,16 @@ public class ClassroomController implements ClassroomOpenApi {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(myClassroomsResponse);
+    }
+
+    @Override
+    @DeleteMapping("/v1/classroom")
+    public ResponseEntity<Void> deleteClassroom(@RequestParam Long classroomId) {
+        classroomService.deleteClassroom(classroomId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .build();
     }
 
     @PostMapping("/v1/classroom/action/init")

--- a/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/ClassroomOpenApi.java
@@ -30,6 +30,14 @@ public interface ClassroomOpenApi {
     })
     ResponseEntity<List<MyClassroomResponse>> getMyClassrooms(Long accountId);
 
+    @Operation(summary = "클래스룸 삭제", description = "클래스룸과 포함된 계정 모두 삭제")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "클래스룸 삭제 성공", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "해당 클래스룸이 없습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<Void> deleteClassroom(@RequestParam Long classroomId);
+
+
     @Operation(summary = "클래스룸에 포함된 계정의 진척도 상태 초기화", description = "클래스룸에 포함된 계정의 진척도 상태 진행중으로 모두 초기화")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "초기화에 성공했습니다.", content = @Content(mediaType = "application/json")),

--- a/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/repository/ClassroomAccountRepository.java
@@ -12,4 +12,6 @@ public interface ClassroomAccountRepository
     boolean existsByAccountIdAndClassroomId(Long accountId, Long classroomId);
 
     Optional<ClassroomAccount> findByClassroomIdAndAccountId(Long classroomId, Long accountId);
+
+    void deleteByClassroomId(Long classroomId);
 }

--- a/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
+++ b/src/main/java/soma/edupimeta/classroom/service/ClassroomService.java
@@ -53,8 +53,17 @@ public class ClassroomService {
         return findMyClassroomsBy(accountId);
     }
 
+    public void deleteClassroom(Long classroomId) {
+        if (isNotExistClassroom(classroomId)) {
+            throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
+        }
+        deleteAllClassroomAccount(classroomId);
+
+        deleteClassroomBy(classroomId);
+    }
+
     public Long initAllActionStatusBy(Long classroomId) {
-        if (isExistClassroom(classroomId)) {
+        if (isNotExistClassroom(classroomId)) {
             throw new ClassroomException(ClassroomErrorEnum.CLASSROOM_NOT_FOUND);
         }
 
@@ -92,8 +101,16 @@ public class ClassroomService {
         return classroomRepository.findMyClassrooms(accountId);
     }
 
-    private boolean isExistClassroom(Long classroomId) {
-        return classroomRepository.existsById(classroomId);
+    private boolean isNotExistClassroom(Long classroomId) {
+        return !classroomRepository.existsById(classroomId);
+    }
+
+    private void deleteAllClassroomAccount(Long classroomId) {
+        classroomAccountRepository.deleteByClassroomId(classroomId);
+    }
+
+    private void deleteClassroomBy(Long classroomId) {
+        classroomRepository.deleteById(classroomId);
     }
 
     private Long initActionStatusBy(Long classroomId) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #47

## 📝 작업 내용

- 클래스룸 설정 페이지에서 클래스룸을 삭제하는 API 제작
- 클래스룸에 포함된 클래스룸 계정도 모두 삭제

### 스크린샷 (선택)

![스크린샷 2024-10-01 13 33 01](https://github.com/user-attachments/assets/66edcee4-a0f9-465f-9734-43a2c2c65518)

## 💬 리뷰 요구사항(선택)
