### PR TITLE
[#64]feat: 클래스룸 계정 역할 확인 api 추가

### DIFF
--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import soma.edupimeta.classroom.account.models.ActionChangeRequest;
 import soma.edupimeta.classroom.account.models.ActionInitRequest;
+import soma.edupimeta.classroom.account.models.CheckClassroomAccountRole;
 import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.ClassroomAccountService;
@@ -100,6 +101,20 @@ public class ClassroomAccountController implements ClassroomAccountOpenApi {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(actionStatus);
+    }
+
+    @Override
+    @GetMapping("/v1/classroom/account/role")
+    public ResponseEntity<CheckClassroomAccountRole> checkClassroomAccountRole(
+        @RequestParam Long accountId,
+        @RequestParam Long classroomId
+    ) {
+        CheckClassroomAccountRole checkClassroomAccountRole =
+            classroomAccountService.checkClassroomAccountRole(accountId, classroomId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(checkClassroomAccountRole);
     }
 
 }

--- a/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
+++ b/src/main/java/soma/edupimeta/classroom/account/ClassroomAccountOpenApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import soma.edupimeta.classroom.account.models.ActionChangeRequest;
 import soma.edupimeta.classroom.account.models.ActionInitRequest;
+import soma.edupimeta.classroom.account.models.CheckClassroomAccountRole;
 import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.models.CreateClassroomAccountRequest;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
@@ -61,4 +62,13 @@ public interface ClassroomAccountOpenApi {
         @ApiResponse(responseCode = "400", description = "상태를 찾을 수 없습니다.", content = @Content(mediaType = "application/json")),
     })
     ResponseEntity<ActionStatus> getActionStatus(@RequestParam Long classroomId, @RequestParam Long accountId);
+
+
+    @Operation(summary = "클래스룸 계정의 권한 조회", description = "클래스룸 계정의 권한 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "권한 조회에 성공했습니다.", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "400", description = "권한을 찾을 수 없습니다.", content = @Content(mediaType = "application/json")),
+    })
+    ResponseEntity<CheckClassroomAccountRole> checkClassroomAccountRole(@RequestParam Long accountId,
+        @RequestParam Long classroomId);
 }

--- a/src/main/java/soma/edupimeta/classroom/account/models/CheckClassroomAccountRole.java
+++ b/src/main/java/soma/edupimeta/classroom/account/models/CheckClassroomAccountRole.java
@@ -1,0 +1,16 @@
+package soma.edupimeta.classroom.account.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CheckClassroomAccountRole {
+
+    @JsonProperty(value = "isAccess")
+    private final boolean isAccess;
+    @JsonProperty(value = "isHost")
+    private final boolean isHost;
+
+    public CheckClassroomAccountRole(boolean isAccess, boolean isHost) {
+        this.isAccess = isAccess;
+        this.isHost = isHost;
+    }
+}

--- a/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupimeta/classroom/account/service/ClassroomAccountService.java
@@ -1,6 +1,7 @@
 package soma.edupimeta.classroom.account.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +11,7 @@ import soma.edupimeta.account.service.domain.Account;
 import soma.edupimeta.account.service.repository.AccountRepository;
 import soma.edupimeta.classroom.account.exception.ClassroomAccountErrorEnum;
 import soma.edupimeta.classroom.account.exception.ClassroomAccountException;
+import soma.edupimeta.classroom.account.models.CheckClassroomAccountRole;
 import soma.edupimeta.classroom.account.models.ClassroomAccountResponse;
 import soma.edupimeta.classroom.account.service.domain.ActionStatus;
 import soma.edupimeta.classroom.account.service.domain.ClassroomAccount;
@@ -107,6 +109,17 @@ public class ClassroomAccountService {
         return classroomAccount.getActionStatus();
     }
 
+    public CheckClassroomAccountRole checkClassroomAccountRole(Long accountId, Long classroomId) {
+        Optional<ClassroomAccount> optionalClassroomAccount =
+            classroomAccountRepository.findByClassroomIdAndAccountId(classroomId, accountId);
+
+        if (optionalClassroomAccount.isEmpty()) {
+            return new CheckClassroomAccountRole(false, false);
+        }
+        ClassroomAccount classroomAccount = optionalClassroomAccount.get();
+
+        return new CheckClassroomAccountRole(true, classroomAccount.getRole().equals(ClassroomAccountRole.HOST));
+    }
 
     private boolean isNotExistClassroom(Long classroomId) {
         return !classroomRepository.existsById(classroomId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #64 

## 📝 작업 내용

- 클래스룸 계정 역할 확인 api 추가

### 스크린샷 (선택)
![스크린샷 2024-11-06 16 50 01](https://github.com/user-attachments/assets/f03b2e32-ec8c-4c5e-8b9c-627d66ea19bb)

isAccess -> 접속 가능 여부
isHost -> 호스트인지 아닌지


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
