### PR TITLE
[#69]fix: 클래스룸 전체 인원 계산 로직 수정

### DIFF
--- a/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
+++ b/src/main/java/soma/edupimeta/classroom/service/repository/ClassroomQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import static soma.edupimeta.classroom.account.service.domain.QClassroomAccount.
 import static soma.edupimeta.classroom.service.domain.QClassroom.classroom;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -43,11 +44,15 @@ public class ClassroomQueryRepositoryImpl implements ClassroomQueryRepository {
                 classroom.id,
                 classroom.name,
                 classroomAccount.role,
-                classroomAccount.id.count().as("totalPeople")
+                JPAExpressions
+                    .select(classroomAccount.id.count())
+                    .from(classroomAccount)
+                    .where(classroomAccount.classroomId.eq(classroom.id))
+                    .where(classroomAccount.role.ne(ClassroomAccountRole.HOST))
             ))
             .from(classroom)
             .leftJoin(classroomAccount)
-            .on(classroomAccount.classroomId.eq(classroom.id))
+            .on(classroom.id.eq(classroomAccount.classroomId))
             .where(classroomAccount.accountId.eq(accountId))
             .groupBy(classroom.id)
             .fetch();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #69 

## 📝 작업 내용

- 클래스룸 전체 인원 계산 로직 수정

### 스크린샷 (선택)
<img width="929" alt="스크린샷 2024-11-13 16 32 34" src="https://github.com/user-attachments/assets/8e0ffbd1-b49d-4e61-897c-8da695ed9fbb">

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
